### PR TITLE
Replace CsvTokenizer's Exceptions not to be inner classes

### DIFF
--- a/src/main/java/org/embulk/parser/csv/QuotedFieldLengthLimitExceededException.java
+++ b/src/main/java/org/embulk/parser/csv/QuotedFieldLengthLimitExceededException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.parser.csv;
+
+public final class QuotedFieldLengthLimitExceededException extends Exception {
+    public QuotedFieldLengthLimitExceededException(final long limit) {
+        super("CsvTokenizer observed a quoted field whose length is longer than " + limit + ".");
+        this.limit = limit;
+    }
+
+    long getLimit() {
+        return this.limit;
+    }
+
+    private final long limit;
+}

--- a/src/main/java/org/embulk/parser/csv/RecordDoesNotHaveExpectedColumnException.java
+++ b/src/main/java/org/embulk/parser/csv/RecordDoesNotHaveExpectedColumnException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.parser.csv;
+
+public final class RecordDoesNotHaveExpectedColumnException extends Exception {
+    public RecordDoesNotHaveExpectedColumnException() {
+        super("CsvTokenizer is requested to retrieve the next column while the current record has no more columns.");
+    }
+}

--- a/src/main/java/org/embulk/parser/csv/RecordHasUnexpectedRemainingColumnException.java
+++ b/src/main/java/org/embulk/parser/csv/RecordHasUnexpectedRemainingColumnException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.parser.csv;
+
+public final class RecordHasUnexpectedRemainingColumnException extends Exception {
+    public RecordHasUnexpectedRemainingColumnException() {
+        super("CsvTokenizer is requested to move to the next record while the current record has unexpected remaining column(s).");
+    }
+}

--- a/src/main/java/org/embulk/parser/csv/UnexpectedCharacterAfterQuoteException.java
+++ b/src/main/java/org/embulk/parser/csv/UnexpectedCharacterAfterQuoteException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.parser.csv;
+
+public final class UnexpectedCharacterAfterQuoteException extends Exception {
+    public UnexpectedCharacterAfterQuoteException(final char unexpected, final char quote) {
+        super(String.format("CsvTokenizer reached at an unexpected extra character '%c' after a quoted field by '%c'", unexpected, quote));
+        this.unexpected = unexpected;
+        this.quote = quote;
+    }
+
+    char getUnexpected() {
+        return this.unexpected;
+    }
+
+    char getQuote() {
+        return this.quote;
+    }
+
+    private final char unexpected;
+    private final char quote;
+}

--- a/src/main/java/org/embulk/parser/csv/UnexpectedEndOfLineInQuotedFieldException.java
+++ b/src/main/java/org/embulk/parser/csv/UnexpectedEndOfLineInQuotedFieldException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.parser.csv;
+
+public final class UnexpectedEndOfLineInQuotedFieldException extends Exception {
+    public UnexpectedEndOfLineInQuotedFieldException() {
+        super("CsvTokenizer reached at an unexpected end of line in a quoted field.");
+    }
+}

--- a/src/test/java/org/embulk/parser/csv/TestCsvTokenizer.java
+++ b/src/test/java/org/embulk/parser/csv/TestCsvTokenizer.java
@@ -80,11 +80,13 @@ public class TestCsvTokenizer {
                         BufferImpl.wrap(text.getBytes(task.getCharset())))));
     }
 
-    private static List<List<String>> parse(CsvParserPlugin.PluginTask task, String... lines) {
+    private static List<List<String>> parse(CsvParserPlugin.PluginTask task, String... lines)
+            throws QuotedFieldLengthLimitExceededException, RecordDoesNotHaveExpectedColumnException, RecordHasUnexpectedRemainingColumnException, UnexpectedCharacterAfterQuoteException, UnexpectedEndOfLineInQuotedFieldException {
         return parse(task, newFileInputFromLines(task, lines));
     }
 
-    private static List<List<String>> parse(CsvParserPlugin.PluginTask task, FileInput input) {
+    private static List<List<String>> parse(CsvParserPlugin.PluginTask task, FileInput input)
+            throws QuotedFieldLengthLimitExceededException, RecordDoesNotHaveExpectedColumnException, RecordHasUnexpectedRemainingColumnException, UnexpectedCharacterAfterQuoteException, UnexpectedEndOfLineInQuotedFieldException {
         LineDecoder decoder = LineDecoder.of(input, task.getCharset(), task.getLineDelimiterRecognized().orElse(null));
         CsvTokenizer tokenizer = new CsvTokenizer(decoder, task);
         Schema schema = task.getSchemaConfig().toSchema();
@@ -321,8 +323,8 @@ public class TestCsvTokenizer {
             parse(task, "\"foo\"bar\",\"hoge\"fuga\"");
             fail();
         } catch (Exception e) {
-            assertTrue(e instanceof CsvTokenizer.InvalidValueException);
-            assertEquals("Unexpected extra character 'b' after a value quoted by '\"'", e.getMessage());
+            assertTrue(e instanceof UnexpectedCharacterAfterQuoteException);
+            assertEquals("CsvTokenizer reached at an unexpected extra character 'b' after a quoted field by '\"'", e.getMessage());
             return;
         }
     }
@@ -336,8 +338,8 @@ public class TestCsvTokenizer {
             parse(task, "\"foo\"bar\",\"hoge\"fuga\"");
             fail();
         } catch (Exception e) {
-            assertTrue(e instanceof CsvTokenizer.InvalidValueException);
-            assertEquals("Unexpected extra character 'b' after a value quoted by '\"'", e.getMessage());
+            assertTrue(e instanceof UnexpectedCharacterAfterQuoteException);
+            assertEquals("CsvTokenizer reached at an unexpected extra character 'b' after a quoted field by '\"'", e.getMessage());
             return;
         }
     }
@@ -370,7 +372,7 @@ public class TestCsvTokenizer {
                     "v3,\"0123456789\"");
             fail();
         } catch (Exception e) {
-            assertTrue(e instanceof CsvTokenizer.QuotedSizeLimitExceededException);
+            assertTrue(e instanceof QuotedFieldLengthLimitExceededException);
         }
 
         // multi-line
@@ -380,7 +382,7 @@ public class TestCsvTokenizer {
                     "\"012345\n6789\",v3");
             fail();
         } catch (Exception e) {
-            assertTrue(e instanceof CsvTokenizer.QuotedSizeLimitExceededException);
+            assertTrue(e instanceof QuotedFieldLengthLimitExceededException);
         }
     }
 
@@ -412,7 +414,7 @@ public class TestCsvTokenizer {
             tokenizer.nextColumn();
             fail();
         } catch (Exception e) {
-            assertTrue(e instanceof CsvTokenizer.QuotedSizeLimitExceededException);
+            assertTrue(e instanceof QuotedFieldLengthLimitExceededException);
         }
         assertEquals("v3,\"0123", tokenizer.skipCurrentLine());
 

--- a/src/test/java/org/embulk/util/csv/TestWithRealFiles.java
+++ b/src/test/java/org/embulk/util/csv/TestWithRealFiles.java
@@ -32,6 +32,11 @@ import java.util.List;
 import org.embulk.config.ConfigSource;
 import org.embulk.parser.csv.CsvParserPlugin;
 import org.embulk.parser.csv.CsvTokenizer;
+import org.embulk.parser.csv.QuotedFieldLengthLimitExceededException;
+import org.embulk.parser.csv.RecordDoesNotHaveExpectedColumnException;
+import org.embulk.parser.csv.RecordHasUnexpectedRemainingColumnException;
+import org.embulk.parser.csv.UnexpectedCharacterAfterQuoteException;
+import org.embulk.parser.csv.UnexpectedEndOfLineInQuotedFieldException;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.FileInput;
 import org.embulk.util.config.ConfigMapperFactory;
@@ -142,7 +147,8 @@ public class TestWithRealFiles {
         assertEquals(expectedRecords, actualRecords);
     }
 
-    private static List<List<String>> tokenizeAll(final CsvTokenizer tokenizer) {
+    private static List<List<String>> tokenizeAll(final CsvTokenizer tokenizer)
+            throws QuotedFieldLengthLimitExceededException, RecordDoesNotHaveExpectedColumnException, RecordHasUnexpectedRemainingColumnException, UnexpectedCharacterAfterQuoteException, UnexpectedEndOfLineInQuotedFieldException {
         final ArrayList<List<String>> records = new ArrayList<>();
         while (tokenizer.nextFile()) {
             if (!tokenizer.nextRecord()) {
@@ -162,11 +168,11 @@ public class TestWithRealFiles {
 
                     try {
                         hasNextRecord = tokenizer.nextRecord();
-                    } catch (final CsvTokenizer.TooManyColumnsException ex) {
+                    } catch (final RecordHasUnexpectedRemainingColumnException ex) {
                         throw ex;
                     }
                     records.add(Collections.unmodifiableList(record));
-                } catch (final CsvTokenizer.InvalidFormatException | CsvTokenizer.InvalidValueException ex) {
+                } catch (final RecordDoesNotHaveExpectedColumnException | RecordHasUnexpectedRemainingColumnException ex) {
                     throw ex;
                 }
 


### PR DESCRIPTION
`CsvTokenizer` has thrown types of Exceptions with its own inner classes. But those Exceptions have been a little bit ambiguous, and inner classes are sometimes annoying to use. Furthermore, `TooManyColumnsException` and `TooFewColumnsException` have been non-`static` inner classes, which are much more annoying to use.

On this chance of externalizing this as a library, changing those Exceptions as independent and self-declarative classes.