### PR TITLE
Make CsvTokenizer independent from CsvParserPlugin

### DIFF
--- a/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
+++ b/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
@@ -314,8 +314,7 @@ public class CsvParserPlugin implements ParserPlugin {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createTaskMapper().map(taskSource, PluginTask.class);
         final TimestampFormatter[] timestampFormatters = newTimestampColumnFormatters(task, task.getSchemaConfig());
         final JsonParser jsonParser = new JsonParser();
-        final CsvTokenizer tokenizer = new CsvTokenizer(
-                LineDecoder.of(input, task.getCharset(), task.getLineDelimiterRecognized().orElse(null)), task);
+        final CsvTokenizer tokenizer = buildCsvTokenizer(task, input);
         final boolean allowOptionalColumns = task.getAllowOptionalColumns();
         final boolean allowExtraColumns = task.getAllowExtraColumns();
         final boolean stopOnInvalidRecord = task.getStopOnInvalidRecord();
@@ -494,6 +493,23 @@ public class CsvParserPlugin implements ParserPlugin {
         CsvRecordValidateException(Throwable cause) {
             super(cause);
         }
+    }
+
+    private static CsvTokenizer buildCsvTokenizer(final PluginTask task, final FileInput input) {
+        final CsvTokenizer.Builder builder = CsvTokenizer.builder(task.getDelimiter());
+        task.getQuoteChar().ifPresent(q -> builder.setQuote(q.getCharacter()));
+        task.getEscapeChar().ifPresent(e -> builder.setEscape(e.getCharacter()));
+        builder.setNewline(task.getNewline().getString());
+        if (task.getTrimIfNotQuoted()) {
+            builder.enableTrimIfNotQuoted();
+        }
+        if (task.getQuotesInQuotedFields() == QuotesInQuotedFields.ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS) {
+            builder.acceptStrayQuotesAssumingNoDelimitersInFields();
+        }
+        builder.setMaxQuotedFieldLength(task.getMaxQuotedSizeLimit());
+        task.getCommentLineMarker().ifPresent(m -> builder.setCommentLineMarker(m));
+        task.getNullString().ifPresent(n -> builder.setNullString(n));
+        return builder.build(LineDecoder.of(input, task.getCharset(), task.getLineDelimiterRecognized().orElse(null)));
     }
 
     @SuppressWarnings("deprecation")  // For the use of new PageBuilder().

--- a/src/main/java/org/embulk/parser/csv/CsvTokenizer.java
+++ b/src/main/java/org/embulk/parser/csv/CsvTokenizer.java
@@ -20,37 +20,34 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-import org.embulk.config.ConfigException;
-import org.embulk.parser.csv.CsvParserPlugin.QuotesInQuotedFields;
+import java.util.stream.Collectors;
 import org.embulk.spi.DataException;
 import org.embulk.util.text.LineDecoder;
 
 public class CsvTokenizer {
-    public CsvTokenizer(final LineDecoder input, final CsvParserPlugin.PluginTask task) {
-        final String delimiter = task.getDelimiter();
-        if (delimiter.length() == 0) {
-            throw new ConfigException("Empty delimiter is not allowed");
-        } else {
-            this.delimiterChar = delimiter.charAt(0);
-            if (delimiter.length() > 1) {
-                this.delimiterFollowingString = delimiter.substring(1);
-            } else {
-                this.delimiterFollowingString = null;
-            }
-        }
-        this.quote = task.getQuoteChar().orElse(CsvParserPlugin.QuoteCharacter.noQuote()).getCharacter();
-        this.escape = task.getEscapeChar().orElse(CsvParserPlugin.EscapeCharacter.noEscape()).getCharacter();
-        this.newline = task.getNewline().getString();
-        this.trimIfNotQuoted = task.getTrimIfNotQuoted();
-        this.quotesInQuotedFields = task.getQuotesInQuotedFields();
-        if (this.trimIfNotQuoted && this.quotesInQuotedFields != QuotesInQuotedFields.ACCEPT_ONLY_RFC4180_ESCAPED) {
-            // The combination makes some syntax very ambiguous such as:
-            //     val1,  \"\"val2\"\"  ,val3
-            throw new ConfigException("[quotes_in_quoted_fields != ACCEPT_ONLY_RFC4180_ESCAPED] is not allowed to specify with [trim_if_not_quoted = true]");
-        }
-        this.maxQuotedSizeLimit = task.getMaxQuotedSizeLimit();
-        this.commentLineMarker = task.getCommentLineMarker().orElse(null);
-        this.nullStringOrNull = task.getNullString().orElse(null);
+    private CsvTokenizer(
+            final LineDecoder input,
+            final char delimiterChar,
+            final String delimiterFollowingString,
+            final char quote,
+            final char escape,
+            final String newline,
+            final boolean trimIfNotQuoted,
+            final QuotesInQuotedFields quotesInQuotedFields,
+            final long maxQuotedFieldLength,
+            final String commentLineMarker,
+            final String nullString) {
+        this.delimiterChar = delimiterChar;
+        this.delimiterFollowingString = delimiterFollowingString;
+        this.quote = quote;
+        this.escape = escape;
+        this.newline = newline;
+        this.trimIfNotQuoted = trimIfNotQuoted;
+        this.quotesInQuotedFields = quotesInQuotedFields;
+        this.maxQuotedFieldLength = maxQuotedFieldLength;
+        this.commentLineMarker = commentLineMarker;
+        this.nullString = nullString;
+
         this.quotedValueLines = new ArrayList<>();
         this.unreadLines = new ArrayDeque<>();
         this.input = input;
@@ -60,6 +57,128 @@ public class CsvTokenizer {
         this.line = null;
         this.linePos = 0;
         this.wasQuotedColumn = false;
+    }
+
+    public static class Builder {
+        private Builder(final String delimiter) {
+            if (delimiter == null) {
+                throw new NullPointerException("CsvTokenizer does not accept null as a delimiter.");
+            }
+            if (delimiter.isEmpty()) {
+                throw new IllegalArgumentException("CsvTokenizer does not accept an empty delimiter.");
+            }
+
+            this.delimiterChar = delimiter.charAt(0);
+            if (delimiter.length() > 1) {
+                this.delimiterFollowingString = delimiter.substring(1);
+            } else {
+                this.delimiterFollowingString = null;
+            }
+
+            this.quote = '\"';
+            this.escape = '\\';
+            this.newline = "\r\n";
+            this.trimIfNotQuoted = false;
+            this.quotesInQuotedFields = QuotesInQuotedFields.ACCEPT_ONLY_RFC4180_ESCAPED;
+            this.maxQuotedFieldLength = 131072L;  // 128KB
+            this.commentLineMarker = null;
+            this.nullString = null;
+        }
+
+        public Builder setQuote(final char quote) {
+            this.quote = quote;
+            return this;
+        }
+
+        public Builder noQuote() {
+            this.quote = NO_QUOTE;
+            return this;
+        }
+
+        public Builder setEscape(final char escape) {
+            this.escape = escape;
+            return this;
+        }
+
+        public Builder noEscape() {
+            this.escape = NO_ESCAPE;
+            return this;
+        }
+
+        public Builder setNewline(final String newline) {
+            if (newline == null) {
+                throw new NullPointerException("CsvTokenizer does not accept null as a newline.");
+            }
+
+            if ("\r\n".equals(newline) || "\r".equals(newline) || "\n".equals(newline)) {
+                this.newline = newline;
+                return this;
+            }
+
+            throw new IllegalArgumentException("CsvTokenizer does not accept \"" + escapeControl(newline) + "\" as a newline.");
+        }
+
+        public Builder enableTrimIfNotQuoted() {
+            this.trimIfNotQuoted = true;
+            return this;
+        }
+
+        public Builder acceptStrayQuotesAssumingNoDelimitersInFields() {
+            this.quotesInQuotedFields = QuotesInQuotedFields.ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS;
+            return this;
+        }
+
+        public Builder setMaxQuotedFieldLength(final long maxQuotedFieldLength) {
+            this.maxQuotedFieldLength = maxQuotedFieldLength;
+            return this;
+        }
+
+        public Builder setCommentLineMarker(final String commentLineMarker) {
+            this.commentLineMarker = commentLineMarker;
+            return this;
+        }
+
+        public Builder setNullString(final String nullString) {
+            this.nullString = nullString;
+            return this;
+        }
+
+        public CsvTokenizer build(final LineDecoder input) {
+            if (this.trimIfNotQuoted && this.quotesInQuotedFields != QuotesInQuotedFields.ACCEPT_ONLY_RFC4180_ESCAPED) {
+                // The combination makes some syntax very ambiguous such as:
+                //     val1,  \"\"val2\"\"  ,val3
+                throw new IllegalStateException(
+                        "[quotes_in_quoted_fields != ACCEPT_ONLY_RFC4180_ESCAPED] is not allowed to specify with [trim_if_not_quoted = true]");
+            }
+            return new CsvTokenizer(
+                    input,
+                    delimiterChar,
+                    delimiterFollowingString,
+                    quote,
+                    escape,
+                    newline,
+                    trimIfNotQuoted,
+                    quotesInQuotedFields,
+                    maxQuotedFieldLength,
+                    commentLineMarker,
+                    nullString);
+        }
+
+        private final char delimiterChar;
+        private final String delimiterFollowingString;
+
+        private char quote;
+        private char escape;
+        private String newline;
+        private boolean trimIfNotQuoted;
+        private QuotesInQuotedFields quotesInQuotedFields;
+        private long maxQuotedFieldLength;
+        private String commentLineMarker;
+        private String nullString;
+    }
+
+    public static Builder builder(final String delimiter) {
+        return new Builder(delimiter);
     }
 
     @Deprecated
@@ -347,8 +466,8 @@ public class CsvTokenizer {
                                 && !(this.isDelimiter(next) || this.isEndOfLine(next))) {
                             // A non-escaped stray "quote character" in the field is processed as a regular character
                             // if ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS is specified,
-                            if ((this.linePos - valueStartPos) + quotedValue.length() > this.maxQuotedSizeLimit) {
-                                throw new QuotedFieldLengthLimitExceededException(this.maxQuotedSizeLimit);
+                            if ((this.linePos - valueStartPos) + quotedValue.length() > this.maxQuotedFieldLength) {
+                                throw new QuotedFieldLengthLimitExceededException(this.maxQuotedFieldLength);
                             }
                         } else {
                             quotedValue.append(this.line.substring(valueStartPos, this.linePos - 1));
@@ -373,8 +492,8 @@ public class CsvTokenizer {
                         }
 
                     } else {
-                        if ((this.linePos - valueStartPos) + quotedValue.length() > this.maxQuotedSizeLimit) {
-                            throw new QuotedFieldLengthLimitExceededException(this.maxQuotedSizeLimit);
+                        if ((this.linePos - valueStartPos) + quotedValue.length() > this.maxQuotedFieldLength) {
+                            throw new QuotedFieldLengthLimitExceededException(this.maxQuotedFieldLength);
                         }
                         // keep QUOTED_VALUE state
                     }
@@ -411,7 +530,7 @@ public class CsvTokenizer {
     public String nextColumnOrNull()
             throws RecordDoesNotHaveExpectedColumnException, RecordHasUnexpectedRemainingColumnException, QuotedFieldLengthLimitExceededException, UnexpectedEndOfLineInQuotedFieldException, UnexpectedCharacterAfterQuoteException {
         final String v = this.nextColumn();
-        if (this.nullStringOrNull == null) {
+        if (this.nullString == null) {
             if (v.isEmpty()) {
                 if (this.wasQuotedColumn) {
                     return "";
@@ -422,7 +541,7 @@ public class CsvTokenizer {
                 return v;
             }
         } else {
-            if (v.equals(this.nullStringOrNull)) {
+            if (v.equals(this.nullString)) {
                 return null;
             } else {
                 return v;
@@ -518,6 +637,35 @@ public class CsvTokenizer {
         BEGIN, VALUE, QUOTED_VALUE, AFTER_QUOTED_VALUE, FIRST_TRIM, LAST_TRIM_OR_VALUE,
     }
 
+    private static enum QuotesInQuotedFields {
+        ACCEPT_ONLY_RFC4180_ESCAPED,
+        ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS,
+        ;
+    }
+
+    private static String escapeControl(final String from) {
+        return from.chars().mapToObj(c -> {
+                if (c > 0x20) {
+                    return "" + (char) c;
+                }
+
+                switch (c) {
+                case '\b':
+                    return "\\b";
+                case '\n':
+                    return "\\n";
+                case '\t':
+                    return "\\t";
+                case '\f':
+                    return "\\f";
+                case '\r':
+                    return "\\r";
+                default:
+                    return String.format("\\u%04x", c);
+                }
+            }).collect(Collectors.joining());
+    }
+
     static final char NO_QUOTE = '\0';
     static final char NO_ESCAPE = '\0';
 
@@ -530,10 +678,11 @@ public class CsvTokenizer {
     private final String newline;
     private final boolean trimIfNotQuoted;
     private final QuotesInQuotedFields quotesInQuotedFields;
-    private final long maxQuotedSizeLimit;
+    private final long maxQuotedFieldLength;
     private final String commentLineMarker;
     private final LineDecoder input;
-    private final String nullStringOrNull;
+    private final String nullString;
+
     private final List<String> quotedValueLines;
     private final Deque<String> unreadLines;
 

--- a/src/test/java/org/embulk/parser/csv/TestCsvTokenizer.java
+++ b/src/test/java/org/embulk/parser/csv/TestCsvTokenizer.java
@@ -20,83 +20,58 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import org.embulk.EmbulkTestRuntime;
-import org.embulk.config.ConfigSource;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.BufferImpl;
 import org.embulk.spi.Column;
 import org.embulk.spi.FileInput;
-import org.embulk.spi.Schema;
-import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.file.ListFileInput;
 import org.embulk.util.text.LineDecoder;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class TestCsvTokenizer {
-    @Rule
-    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
-
-    protected ConfigSource config;
-    protected CsvParserPlugin.PluginTask task;
-
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
-
-    @Before
-    public void setup() {
-        config = CONFIG_MAPPER_FACTORY.newConfigSource()
-            .set("newline", "LF")
-            .set("columns", ImmutableList.of(
-                        ImmutableMap.<String,Object>of(
-                            "name", "date_code", "type", "string", "option", ImmutableMap.of()),
-                        ImmutableMap.<String,Object>of(
-                            "name", "foo", "type", "string", "option", ImmutableMap.of()))
-                );
-        reloadPluginTask();
+    private static CsvTokenizer.Builder initialBuilder(final String delimiter) {
+        return CsvTokenizer.builder(delimiter).setNewline("\n");
     }
 
-    private void reloadPluginTask() {
-        task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+    private static CsvTokenizer.Builder initialBuilder() {
+        return initialBuilder(",");
     }
 
-    private static FileInput newFileInputFromLines(CsvParserPlugin.PluginTask task, String... lines) {
+    private static FileInput newFileInputFromLines(final String newline, final String... lines) {
         List<Buffer> buffers = new ArrayList<>();
         for (String line : lines) {
-            byte[] buffer = (line + task.getNewline().getString()).getBytes(task.getCharset());
+            byte[] buffer = (line + newline).getBytes(StandardCharsets.UTF_8);
             buffers.add(BufferImpl.wrap(buffer));
         }
-        return new ListFileInput(ImmutableList.of(buffers));
+        return new ListFileInput(Arrays.asList(buffers));
     }
 
-    private static FileInput newFileInputFromText(CsvParserPlugin.PluginTask task, String text) {
+    private static FileInput newFileInputFromText(final String newline, final String text) {
         return new ListFileInput(
-                ImmutableList.of(ImmutableList.of(
-                        BufferImpl.wrap(text.getBytes(task.getCharset())))));
+                Arrays.asList(Arrays.asList(
+                        BufferImpl.wrap(text.getBytes(StandardCharsets.UTF_8)))));
     }
 
-    private static List<List<String>> parse(CsvParserPlugin.PluginTask task, String... lines)
+    private static List<List<String>> parse(final CsvTokenizer.Builder builder, final String newline, final int columns, final String... lines)
             throws QuotedFieldLengthLimitExceededException, RecordDoesNotHaveExpectedColumnException, RecordHasUnexpectedRemainingColumnException, UnexpectedCharacterAfterQuoteException, UnexpectedEndOfLineInQuotedFieldException {
-        return parse(task, newFileInputFromLines(task, lines));
+        return parse(builder, columns, newFileInputFromLines(newline, lines));
     }
 
-    private static List<List<String>> parse(CsvParserPlugin.PluginTask task, FileInput input)
+    private static List<List<String>> parse(final CsvTokenizer.Builder builder, final int columns, final FileInput input)
             throws QuotedFieldLengthLimitExceededException, RecordDoesNotHaveExpectedColumnException, RecordHasUnexpectedRemainingColumnException, UnexpectedCharacterAfterQuoteException, UnexpectedEndOfLineInQuotedFieldException {
-        LineDecoder decoder = LineDecoder.of(input, task.getCharset(), task.getLineDelimiterRecognized().orElse(null));
-        CsvTokenizer tokenizer = new CsvTokenizer(decoder, task);
-        Schema schema = task.getSchemaConfig().toSchema();
+        LineDecoder decoder = LineDecoder.of(input, StandardCharsets.UTF_8, null);
+        final CsvTokenizer tokenizer = builder.build(decoder);
 
         tokenizer.nextFile();
 
         List<List<String>> records = new ArrayList<>();
         while (tokenizer.nextRecord()) {
             List<String> record = new ArrayList<>();
-            for (Column c : schema.getColumns()) {
+            for (int i = 0; i < columns; i++) {
                 String v = tokenizer.nextColumnOrNull();
                 record.add(v);
             }
@@ -120,31 +95,34 @@ public class TestCsvTokenizer {
 
     @Test
     public void testSimple() throws Exception {
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(2,
                     "aaa", "bbb",
                     "ccc", "ddd"),
-                parse(task,
+                parse(builder, "\n", 2,
                     "aaa,bbb",
                     "ccc,ddd"));
     }
 
     @Test
     public void testSkipEmptyLine() throws Exception {
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(2,
                     "aaa", "bbb",
                     "ccc", "ddd"),
-                parse(task,
+                parse(builder, "\n", 2,
                     "", "aaa,bbb", "", "",
                     "ccc,ddd", "", ""));
     }
 
     @Test
     public void parseEmptyColumnsToNull() throws Exception {
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(2,
                     null, null,
                     "", "",
                     "  ", "  "), // not trimmed
-                parse(task,
+                parse(builder, "\n", 2,
                     ",",
                     "\"\",\"\"",
                     "  ,  "));
@@ -152,14 +130,14 @@ public class TestCsvTokenizer {
 
     @Test
     public void parseEmptyColumnsToNullTrimmed() throws Exception {
-        config.set("trim_if_not_quoted", true);
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
+        builder.enableTrimIfNotQuoted();
         assertEquals(
                 expectedRecords(2,
                     null, null,
                     "", "",
                     null, null),  // trimmed
-                parse(task,
+                parse(builder, "\n", 2,
                     ",",
                     "\"\",\"\"",
                     "  ,  "));
@@ -167,10 +145,11 @@ public class TestCsvTokenizer {
 
     @Test
     public void testMultilineQuotedValueWithEmptyLine() throws Exception {
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(2,
                     "a", "\nb\n\n",
                     "c", "d"),
-                parse(task,
+                parse(builder, "\n", 2,
                     "",
                     "a,\"", "b", "", "\"",
                     "c,d"));
@@ -178,78 +157,80 @@ public class TestCsvTokenizer {
 
     @Test
     public void testEndOfFileWithoutNewline() throws Exception {
+        final CsvTokenizer.Builder builder = initialBuilder();
         // In RFC 4180, the last record in the file may or may not have
         // an ending line break.
         assertEquals(expectedRecords(2,
                         "aaa", "bbb",
                         "ccc", "ddd"),
-                parse(task, newFileInputFromText(task,
+                parse(builder, 2, newFileInputFromText("\n",
                         "aaa,bbb\nccc,ddd")));
     }
 
     @Test
     public void testChangeDelimiter() throws Exception {
-        config.set("delimiter", JsonNodeFactory.instance.textNode("\t")); // TSV format
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder("\t");  // TSV format
         assertEquals(expectedRecords(2,
                         "aaa", "bbb",
                         "ccc", "ddd"),
-                parse(task,
+                parse(builder, "\n", 2,
                         "aaa\tbbb",
                         "ccc\tddd"));
     }
 
     @Test
     public void testDefaultNullString() throws Exception {
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(2,
                         null, "",
                         "NULL", "NULL"),
-                parse(task,
+                parse(builder, "\n", 2,
                         ",\"\"",
                         "NULL,\"NULL\""));
     }
 
     @Test
     public void testChangeNullString() throws Exception {
-        config.set("null_string", "NULL");
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
+        builder.setNullString("NULL");
         assertEquals(expectedRecords(2,
                         "", "",
                         null, null),
-                parse(task,
+                parse(builder, "\n", 2,
                         ",\"\"",
                         "NULL,\"NULL\""));
     }
 
     @Test
     public void testQuotedValues() throws Exception {
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(2,
                         "a\na\na", "b,bb",
                         "cc\"c", "\"ddd",
                         null, ""),
-                parse(task, newFileInputFromText(task,
+                parse(builder, 2, newFileInputFromText("\r\n",
                         "\n\"a\na\na\",\"b,bb\"\n\n\"cc\"\"c\",\"\"\"ddd\"\n,\"\"\n")));
     }
 
     @Test
     public void parseEscapedValues() throws Exception {
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(2,
                         "a\"aa", "b,bb\"",
                         "cc\"c", "\"ddd",
                         null, ""),
-                parse(task, newFileInputFromText(task,
+                parse(builder, 2, newFileInputFromText("\r\n",
                     "\n\"a\\\"aa\",\"b,bb\\\"\"\n\n\"cc\"\"c\",\"\"\"ddd\"\n,\"\"\n")));
     }
 
     @Test
     public void testCommentLineMarker() throws Exception {
-        config.set("comment_line_marker", JsonNodeFactory.instance.textNode("#"));
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
+        builder.setCommentLineMarker("#");
         assertEquals(expectedRecords(2,
                         "aaa", "bbb",
                         "eee", "fff"),
-                parse(task,
+                parse(builder, "\n", 2,
                         "aaa,bbb",
                         "#ccc,ddd",
                         "eee,fff"));
@@ -257,31 +238,32 @@ public class TestCsvTokenizer {
 
     @Test
     public void trimNonQuotedValues() throws Exception {
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(2,
                     "  aaa  ", "  b cd ",
                     "  ccc","dd d \n "), // quoted values are not changed
-                parse(task, newFileInputFromText(task,
+                parse(builder, 2, newFileInputFromText("\n",
                         "  aaa  ,  b cd \n\"  ccc\",\"dd d \n \"")));
 
+        final CsvTokenizer.Builder builder2 = initialBuilder();
         // trim_if_not_quoted is true
-        config.set("trim_if_not_quoted", true);
-        reloadPluginTask();
+        builder2.enableTrimIfNotQuoted();
         assertEquals(expectedRecords(2,
                     "aaa", "b cd",
                     "  ccc","dd d \n "), // quoted values are not changed
-                parse(task, newFileInputFromText(task,
+                parse(builder2, 2, newFileInputFromText("\n",
                         "  aaa  ,  b cd \n\"  ccc\",\"dd d \n \"")));
     }
 
     @Test
     public void parseQuotedValueWithSpacesAndTrimmingOption() throws Exception {
-        config.set("trim_if_not_quoted", true);
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
+        builder.enableTrimIfNotQuoted();
         assertEquals(expectedRecords(2,
                         "heading1", "heading2",
                         "trailing1","trailing2",
                         "trailing\n3","trailing\n4"),
-                parse(task,
+                parse(builder, "\n", 2,
                     "  \"heading1\",  \"heading2\"",
                     "\"trailing1\"  ,\"trailing2\"  ",
                     "\"trailing\n3\"  ,\"trailing\n4\"  "));
@@ -290,13 +272,13 @@ public class TestCsvTokenizer {
 
     @Test
     public void parseWithDefaultQuotesInQuotedFields() throws Exception {
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(
                          2,
                          "foo\"bar", "foofoo\"barbar",
                          "baz\"\"qux", "bazbaz\"\"quxqux"),
                      parse(
-                         task,
+                         builder, "\n", 2,
                          "\"foo\"\"bar\",\"foofoo\"\"barbar\"",
                          "\"baz\"\"\"\"qux\",\"bazbaz\"\"\"\"quxqux\""));
     }
@@ -304,23 +286,22 @@ public class TestCsvTokenizer {
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
     public void parseWithQuotesInQuotedFields_ACCEPT_ONLY_RFC4180_ESCAPED() throws Exception {
-        config.set("quotes_in_quoted_fields", "ACCEPT_ONLY_RFC4180_ESCAPED");
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
         assertEquals(expectedRecords(
                          2,
                          "foo\"bar", "foofoo\"barbar",
                          "baz\"\"qux", "bazbaz\"\"quxqux"),
                      parse(
-                         task,
+                         builder, "\n", 2,
                          "\"foo\"\"bar\",\"foofoo\"\"barbar\"",
                          "\"baz\"\"\"\"qux\",\"bazbaz\"\"\"\"quxqux\""));
     }
 
     @Test
     public void throwWithDefaultQuotesInQuotedFields() throws Exception {
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
         try {
-            parse(task, "\"foo\"bar\",\"hoge\"fuga\"");
+            parse(builder, "\n", 2, "\"foo\"bar\",\"hoge\"fuga\"");
             fail();
         } catch (Exception e) {
             assertTrue(e instanceof UnexpectedCharacterAfterQuoteException);
@@ -332,10 +313,9 @@ public class TestCsvTokenizer {
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
     public void throwWithQuotesInQuotedFields_ACCEPT_ONLY_RFC4180_ESCAPED() throws Exception {
-        config.set("quotes_in_quoted_fields", "ACCEPT_ONLY_RFC4180_ESCAPED");
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
         try {
-            parse(task, "\"foo\"bar\",\"hoge\"fuga\"");
+            parse(builder, "\n", 2, "\"foo\"bar\",\"hoge\"fuga\"");
             fail();
         } catch (Exception e) {
             assertTrue(e instanceof UnexpectedCharacterAfterQuoteException);
@@ -347,15 +327,15 @@ public class TestCsvTokenizer {
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
     public void parseWithQuotesInQuotedFields_ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS() throws Exception {
-        config.set("quotes_in_quoted_fields", "ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS");
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
+        builder.acceptStrayQuotesAssumingNoDelimitersInFields();
         assertEquals(expectedRecords(
                          2,
                          "foo\"bar", "foofoo\"barbar",
                          "baz\"\"qux", "bazbaz\"\"quxqux",
                          "\"embulk\"", "\"embul\"\"k\""),
                      parse(
-                         task,
+                         builder, "\n", 2,
                          "\"foo\"bar\",\"foofoo\"\"barbar\"",
                          "\"baz\"\"\"qux\",\"bazbaz\"\"\"\"quxqux\"",
                          "\"\"\"embulk\"\",\"\"embul\"\"\"k\"\""));
@@ -363,11 +343,11 @@ public class TestCsvTokenizer {
 
     @Test
     public void throwQuotedSizeLimitExceededException() throws Exception {
-        config.set("max_quoted_size_limit", 8);
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
+        builder.setMaxQuotedFieldLength(8);
 
         try {
-            parse(task,
+            parse(builder, "\n", 2,
                     "v1,v2",
                     "v3,\"0123456789\"");
             fail();
@@ -377,7 +357,7 @@ public class TestCsvTokenizer {
 
         // multi-line
         try {
-            parse(task,
+            parse(builder, "\n", 2,
                     "v1,v2",
                     "\"012345\n6789\",v3");
             fail();
@@ -388,8 +368,8 @@ public class TestCsvTokenizer {
 
     @Test
     public void recoverFromQuotedSizeLimitExceededException() throws Exception {
-        config.set("max_quoted_size_limit", 12);
-        reloadPluginTask();
+        final CsvTokenizer.Builder builder = initialBuilder();
+        builder.setMaxQuotedFieldLength(12);
 
         String[] lines = new String[] {
             "v1,v2",
@@ -397,10 +377,9 @@ public class TestCsvTokenizer {
             "v4,v5",      // this line should be not be skiped
             "v6,v7",      // this line should be not be skiped
         };
-        FileInput input = newFileInputFromLines(task, lines);
-        LineDecoder decoder = LineDecoder.of(input, task.getCharset(), task.getLineDelimiterRecognized().orElse(null));
-        CsvTokenizer tokenizer = new CsvTokenizer(decoder, task);
-        Schema schema = task.getSchemaConfig().toSchema();
+        final FileInput input = newFileInputFromLines("\n", lines);
+        final LineDecoder decoder = LineDecoder.of(input, StandardCharsets.UTF_8, null);
+        final CsvTokenizer tokenizer = builder.build(decoder);
 
         tokenizer.nextFile();
 

--- a/src/test/java/org/embulk/util/csv/TestWithRealFiles.java
+++ b/src/test/java/org/embulk/util/csv/TestWithRealFiles.java
@@ -19,7 +19,6 @@ package org.embulk.util.csv;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -29,8 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.embulk.config.ConfigSource;
-import org.embulk.parser.csv.CsvParserPlugin;
 import org.embulk.parser.csv.CsvTokenizer;
 import org.embulk.parser.csv.QuotedFieldLengthLimitExceededException;
 import org.embulk.parser.csv.RecordDoesNotHaveExpectedColumnException;
@@ -39,7 +36,6 @@ import org.embulk.parser.csv.UnexpectedCharacterAfterQuoteException;
 import org.embulk.parser.csv.UnexpectedEndOfLineInQuotedFieldException;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.FileInput;
-import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.text.LineDecoder;
 import org.embulk.util.text.LineDelimiter;
 import org.junit.Test;
@@ -50,40 +46,13 @@ public class TestWithRealFiles {
         final LineDecoder input = LineDecoder.of(
                 new ResourceFileInput("test_simple.csv"), StandardCharsets.UTF_8, LineDelimiter.LF);
 
-        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource();
-        config.set("charset", "UTF-8");
-        config.set("newline", "LF");
-        config.set("type", "csv");
-        config.set("delimiter", ",");
-        config.set("quote", "\"");
-        config.set("escape", "\"");
-        config.set("null_string", "NULL");
-        config.set("trim_if_not_quoted", false);
-        config.set("skip_header_lines", 1);
-        config.set("allow_extra_columns", false);
-        config.set("allow_optional_columns", false);
-        final ConfigSource column0 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column0.set("name", "id");
-        column0.set("type", "long");
-        final ConfigSource column1 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column1.set("name", "account");
-        column1.set("type", "long");
-        final ConfigSource column2 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column2.set("name", "time");
-        column2.set("type", "timestamp");
-        column2.set("format", "%Y-%m-%d %H:%M:%S");
-        final ConfigSource column3 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column3.set("name", "purchase");
-        column3.set("type", "timestamp");
-        column3.set("format", "%Y%m%d");
-        final ConfigSource column4 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column4.set("name", "comment");
-        column4.set("type", "string");
-        config.set("columns", Arrays.asList(column0, column1, column2, column3, column4));
-        final CsvParserPlugin.PluginTask task =
-                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+        final CsvTokenizer tokenizer = CsvTokenizer.builder(",")
+                .setNewline("\n")
+                .setQuote('\"')
+                .setEscape('\"')
+                .setNullString("NULL")
+                .build(input);
 
-        final CsvTokenizer tokenizer = new CsvTokenizer(input, task);
         final List<List<String>> actualRecords = tokenizeAll(tokenizer);
 
         final List<List<String>> expectedRecords = Arrays.asList(
@@ -101,40 +70,13 @@ public class TestWithRealFiles {
         final LineDecoder input = LineDecoder.of(
                 new ResourceFileInput("test_sample_buffer_bytes.csv"), StandardCharsets.UTF_8, LineDelimiter.LF);
 
-        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource();
-        config.set("charset", "UTF-8");
-        config.set("newline", "LF");
-        config.set("type", "csv");
-        config.set("delimiter", ",");
-        config.set("quote", "\"");
-        config.set("escape", "\"");
-        config.set("null_string", "NULL");
-        config.set("trim_if_not_quoted", false);
-        config.set("skip_header_lines", 1);
-        config.set("allow_extra_columns", false);
-        config.set("allow_optional_columns", false);
-        final ConfigSource column0 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column0.set("name", "id");
-        column0.set("type", "long");
-        final ConfigSource column1 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column1.set("name", "account");
-        column1.set("type", "long");
-        final ConfigSource column2 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column2.set("name", "time");
-        column2.set("type", "timestamp");
-        column2.set("format", "%Y-%m-%d %H:%M:%S");
-        final ConfigSource column3 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column3.set("name", "purchase");
-        column3.set("type", "timestamp");
-        column3.set("format", "%Y%m%d");
-        final ConfigSource column4 = CONFIG_MAPPER_FACTORY.newConfigSource();
-        column4.set("name", "comment");
-        column4.set("type", "string");
-        config.set("columns", Arrays.asList(column0, column1, column2, column3, column4));
-        final CsvParserPlugin.PluginTask task =
-                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+        final CsvTokenizer tokenizer = CsvTokenizer.builder(",")
+                .setNewline("\n")
+                .setQuote('\"')
+                .setEscape('\"')
+                .setNullString("NULL")
+                .build(input);
 
-        final CsvTokenizer tokenizer = new CsvTokenizer(input, task);
         final List<List<String>> actualRecords = tokenizeAll(tokenizer);
 
         final List<List<String>> expectedRecords = Arrays.asList(
@@ -223,6 +165,4 @@ public class TestWithRealFiles {
         private boolean hasFilePointed;
         private boolean hasPolled;
     }
-
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }


### PR DESCRIPTION
`CsvTokenizer` has been constructed with `CsvParserPlugin.PluginTask`. It made `CsvTokenizer` tightly coupled with `CsvParserPlugin`, but it is not an essentially-required dependency. `CsvTokenizer` can be independent.

Instead of `CsvParserPlugin.PluginTask`, this PR implements a builder-style construction of `CsvTokenizer`.