### PR TITLE
Make CsvTokenizer independent from LineDecoder

### DIFF
--- a/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
+++ b/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
@@ -314,14 +314,17 @@ public class CsvParserPlugin implements ParserPlugin {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createTaskMapper().map(taskSource, PluginTask.class);
         final TimestampFormatter[] timestampFormatters = newTimestampColumnFormatters(task, task.getSchemaConfig());
         final JsonParser jsonParser = new JsonParser();
-        final CsvTokenizer tokenizer = buildCsvTokenizer(task, input);
+        final CsvTokenizer.Builder tokenizerBuilder = buildCsvTokenizerBuilder(task);
         final boolean allowOptionalColumns = task.getAllowOptionalColumns();
         final boolean allowExtraColumns = task.getAllowExtraColumns();
         final boolean stopOnInvalidRecord = task.getStopOnInvalidRecord();
         final int skipHeaderLines = task.getSkipHeaderLines();
 
         try (final PageBuilder pageBuilder = getPageBuilder(Exec.getBufferAllocator(), schema, output)) {
-            while (tokenizer.nextFile()) {
+            while (input.nextFile()) {
+                final CsvTokenizer tokenizer = tokenizerBuilder.build(
+                        LineDecoder.of(input, task.getCharset(), task.getLineDelimiterRecognized().orElse(null)).iterator());
+
                 final String fileName = input.hintOfCurrentInputFileNameForLogging().orElse("-");
 
                 // skip the header lines for each file
@@ -495,7 +498,7 @@ public class CsvParserPlugin implements ParserPlugin {
         }
     }
 
-    private static CsvTokenizer buildCsvTokenizer(final PluginTask task, final FileInput input) {
+    private static CsvTokenizer.Builder buildCsvTokenizerBuilder(final PluginTask task) {
         final CsvTokenizer.Builder builder = CsvTokenizer.builder(task.getDelimiter());
         task.getQuoteChar().ifPresent(q -> builder.setQuote(q.getCharacter()));
         task.getEscapeChar().ifPresent(e -> builder.setEscape(e.getCharacter()));
@@ -509,7 +512,7 @@ public class CsvParserPlugin implements ParserPlugin {
         builder.setMaxQuotedFieldLength(task.getMaxQuotedSizeLimit());
         task.getCommentLineMarker().ifPresent(m -> builder.setCommentLineMarker(m));
         task.getNullString().ifPresent(n -> builder.setNullString(n));
-        return builder.build(LineDecoder.of(input, task.getCharset(), task.getLineDelimiterRecognized().orElse(null)));
+        return builder;
     }
 
     @SuppressWarnings("deprecation")  // For the use of new PageBuilder().

--- a/src/main/java/org/embulk/parser/csv/CsvTokenizer.java
+++ b/src/main/java/org/embulk/parser/csv/CsvTokenizer.java
@@ -19,6 +19,7 @@ package org.embulk.parser.csv;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.embulk.spi.DataException;
@@ -51,6 +52,7 @@ public class CsvTokenizer {
         this.quotedValueLines = new ArrayList<>();
         this.unreadLines = new ArrayDeque<>();
         this.input = input;
+        this.iterator = input.iterator();
 
         this.recordState = RecordState.END;  // initial state is end of a record. nextRecord() must be called first
         this.lineNumber = 0;
@@ -221,11 +223,12 @@ public class CsvTokenizer {
     }
 
     public boolean skipHeaderLine() {
-        final boolean skipped = this.input.poll() != null;
-        if (skipped) {
-            this.lineNumber++;
+        if (!this.iterator.hasNext()) {
+            return false;
         }
-        return skipped;
+        this.iterator.next();
+        this.lineNumber++;
+        return true;
     }
 
     // returns skipped line
@@ -281,10 +284,10 @@ public class CsvTokenizer {
             if (!this.unreadLines.isEmpty()) {
                 this.line = this.unreadLines.removeFirst();
             } else {
-                this.line = this.input.poll();
-                if (this.line == null) {
+                if (!this.iterator.hasNext()) {
                     return false;
                 }
+                this.line = this.iterator.next();
             }
             this.linePos = 0;
             this.lineNumber++;
@@ -670,6 +673,8 @@ public class CsvTokenizer {
     static final char NO_ESCAPE = '\0';
 
     private static final char END_OF_LINE = '\0';
+
+    private final Iterator<String> iterator;
 
     private final char delimiterChar;
     private final String delimiterFollowingString;

--- a/src/main/java/org/embulk/parser/csv/CsvTokenizer.java
+++ b/src/main/java/org/embulk/parser/csv/CsvTokenizer.java
@@ -23,11 +23,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.embulk.spi.DataException;
-import org.embulk.util.text.LineDecoder;
 
 public class CsvTokenizer {
     private CsvTokenizer(
-            final LineDecoder input,
+            final Iterator<String> iterator,
             final char delimiterChar,
             final String delimiterFollowingString,
             final char quote,
@@ -51,8 +50,7 @@ public class CsvTokenizer {
 
         this.quotedValueLines = new ArrayList<>();
         this.unreadLines = new ArrayDeque<>();
-        this.input = input;
-        this.iterator = input.iterator();
+        this.iterator = iterator;
 
         this.recordState = RecordState.END;  // initial state is end of a record. nextRecord() must be called first
         this.lineNumber = 0;
@@ -145,7 +143,7 @@ public class CsvTokenizer {
             return this;
         }
 
-        public CsvTokenizer build(final LineDecoder input) {
+        public CsvTokenizer build(final Iterator<String> iterator) {
             if (this.trimIfNotQuoted && this.quotesInQuotedFields != QuotesInQuotedFields.ACCEPT_ONLY_RFC4180_ESCAPED) {
                 // The combination makes some syntax very ambiguous such as:
                 //     val1,  \"\"val2\"\"  ,val3
@@ -153,7 +151,7 @@ public class CsvTokenizer {
                         "[quotes_in_quoted_fields != ACCEPT_ONLY_RFC4180_ESCAPED] is not allowed to specify with [trim_if_not_quoted = true]");
             }
             return new CsvTokenizer(
-                    input,
+                    iterator,
                     delimiterChar,
                     delimiterFollowingString,
                     quote,
@@ -249,14 +247,6 @@ public class CsvTokenizer {
         }
         this.recordState = RecordState.END;
         return skippedLine;
-    }
-
-    public boolean nextFile() {
-        final boolean next = this.input.nextFile();
-        if (next) {
-            this.lineNumber = 0;
-        }
-        return next;
     }
 
     // used by guess-csv
@@ -685,7 +675,6 @@ public class CsvTokenizer {
     private final QuotesInQuotedFields quotesInQuotedFields;
     private final long maxQuotedFieldLength;
     private final String commentLineMarker;
-    private final LineDecoder input;
     private final String nullString;
 
     private final List<String> quotedValueLines;

--- a/src/test/java/org/embulk/parser/csv/TestCsvTokenizer.java
+++ b/src/test/java/org/embulk/parser/csv/TestCsvTokenizer.java
@@ -64,9 +64,8 @@ public class TestCsvTokenizer {
     private static List<List<String>> parse(final CsvTokenizer.Builder builder, final int columns, final FileInput input)
             throws QuotedFieldLengthLimitExceededException, RecordDoesNotHaveExpectedColumnException, RecordHasUnexpectedRemainingColumnException, UnexpectedCharacterAfterQuoteException, UnexpectedEndOfLineInQuotedFieldException {
         LineDecoder decoder = LineDecoder.of(input, StandardCharsets.UTF_8, null);
-        final CsvTokenizer tokenizer = builder.build(decoder);
-
-        tokenizer.nextFile();
+        decoder.nextFile();
+        final CsvTokenizer tokenizer = builder.build(decoder.iterator());
 
         List<List<String>> records = new ArrayList<>();
         while (tokenizer.nextRecord()) {
@@ -379,9 +378,8 @@ public class TestCsvTokenizer {
         };
         final FileInput input = newFileInputFromLines("\n", lines);
         final LineDecoder decoder = LineDecoder.of(input, StandardCharsets.UTF_8, null);
-        final CsvTokenizer tokenizer = builder.build(decoder);
-
-        tokenizer.nextFile();
+        decoder.nextFile();
+        final CsvTokenizer tokenizer = builder.build(decoder.iterator());
 
         assertTrue(tokenizer.nextRecord());
         assertEquals("v1", tokenizer.nextColumn());

--- a/src/test/java/org/embulk/util/csv/TestWithRealFiles.java
+++ b/src/test/java/org/embulk/util/csv/TestWithRealFiles.java
@@ -46,14 +46,13 @@ public class TestWithRealFiles {
         final LineDecoder input = LineDecoder.of(
                 new ResourceFileInput("test_simple.csv"), StandardCharsets.UTF_8, LineDelimiter.LF);
 
-        final CsvTokenizer tokenizer = CsvTokenizer.builder(",")
+        final CsvTokenizer.Builder tokenizerBuilder = CsvTokenizer.builder(",")
                 .setNewline("\n")
                 .setQuote('\"')
                 .setEscape('\"')
-                .setNullString("NULL")
-                .build(input);
+                .setNullString("NULL");
 
-        final List<List<String>> actualRecords = tokenizeAll(tokenizer);
+        final List<List<String>> actualRecords = tokenizeAll(tokenizerBuilder, input);
 
         final List<List<String>> expectedRecords = Arrays.asList(
                 Arrays.asList("id", "account", "time", "purchase", "comment"),
@@ -70,14 +69,13 @@ public class TestWithRealFiles {
         final LineDecoder input = LineDecoder.of(
                 new ResourceFileInput("test_sample_buffer_bytes.csv"), StandardCharsets.UTF_8, LineDelimiter.LF);
 
-        final CsvTokenizer tokenizer = CsvTokenizer.builder(",")
+        final CsvTokenizer.Builder tokenizerBuilder = CsvTokenizer.builder(",")
                 .setNewline("\n")
                 .setQuote('\"')
                 .setEscape('\"')
-                .setNullString("NULL")
-                .build(input);
+                .setNullString("NULL");
 
-        final List<List<String>> actualRecords = tokenizeAll(tokenizer);
+        final List<List<String>> actualRecords = tokenizeAll(tokenizerBuilder, input);
 
         final List<List<String>> expectedRecords = Arrays.asList(
                 Arrays.asList("id", "account", "time", "purchase", "comment"),
@@ -89,10 +87,11 @@ public class TestWithRealFiles {
         assertEquals(expectedRecords, actualRecords);
     }
 
-    private static List<List<String>> tokenizeAll(final CsvTokenizer tokenizer)
+    private static List<List<String>> tokenizeAll(final CsvTokenizer.Builder tokenizerBuilder, final LineDecoder input)
             throws QuotedFieldLengthLimitExceededException, RecordDoesNotHaveExpectedColumnException, RecordHasUnexpectedRemainingColumnException, UnexpectedCharacterAfterQuoteException, UnexpectedEndOfLineInQuotedFieldException {
         final ArrayList<List<String>> records = new ArrayList<>();
-        while (tokenizer.nextFile()) {
+        while (input.nextFile()) {
+            final CsvTokenizer tokenizer = tokenizerBuilder.build(input.iterator());
             if (!tokenizer.nextRecord()) {
                 // empty file
                 continue;


### PR DESCRIPTION
`CsvTokenizer` has been constructed with `LineDecoder` from `embulk-util-text`. It made `CsvTokenizer` depends on `embulk-util-text`, but it is not an essentially-required dependency. `LineDecoder` inherits `Iterable<String>`.

Instead of `LineDecoder`, this PR modifies `CsvTokenizer` with `Iterator<String>`. We have to give up `CsvTokenizer#nextFile`, but users of `CsvTokenizer` can call `FileInput#nextFile` on their side.