### PR TITLE
Sync the "master" branch to "main"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Sync master to main
+on:
+  push:
+    branches:
+      - "master"
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    outputs:
+      hash-master: ${{ steps.hash-master.outputs.hash-master }}
+      hash-main: ${{ steps.hash-main.outputs.hash-main }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - id: hash-master
+      name: Hash the master branch
+      run: |
+        hash_master=$( git rev-parse origin/master )
+        echo "$hash_master"
+        echo "hash-master=$hash_master" >> $GITHUB_OUTPUT
+    - id: hash-main
+      name: Hash the main branch
+      run: |
+        hash_main=$( git rev-parse origin/main )
+        echo "$hash_main"
+        echo "hash-main=$hash_main" >> $GITHUB_OUTPUT
+  sync:
+    needs: diff
+    if: needs.diff.outputs.hash-master != needs.diff.outputs.hash-main
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Checkout master
+      run: git checkout master
+    - name: Sync master to main
+      run: git push origin master:main


### PR DESCRIPTION
The mainstream of Git default branches is now `main`, not `master`.

https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/

But, changing the default branch is often not very easy in historical repositories because some external environments often expect an older conventions.

For a smoother migration, this pull request is a trick to sync `master` to `main` automatically so that external environments can catch up with `main` while `main` is synchronized to `master`.