### PR TITLE
Make the constants NO_QUOTE and NO_ESCAPE public

### DIFF
--- a/src/main/java/org/embulk/util/csv/CsvTokenizer.java
+++ b/src/main/java/org/embulk/util/csv/CsvTokenizer.java
@@ -761,8 +761,8 @@ public class CsvTokenizer {
         }).collect(Collectors.joining());
     }
 
-    static final char NO_QUOTE = '\0';
-    static final char NO_ESCAPE = '\0';
+    public static final char NO_QUOTE = '\0';
+    public static final char NO_ESCAPE = '\0';
 
     private static final char END_OF_LINE = '\0';
 


### PR DESCRIPTION
When tried to replace the `CsvTokenizer` in `embulk-parser-csv` to `embulk-util-csv`, I found that `NO_QUOTE` and `NO_ESCAPE` were not accessible.