### PR TITLE
Group RecordDoesNotHaveExpectedColumnException and RecordHasUnexpectedTrailingColumnException as InvalidCsvColumnsException

### DIFF
--- a/src/main/java/org/embulk/util/csv/InvalidCsvColumnsException.java
+++ b/src/main/java/org/embulk/util/csv/InvalidCsvColumnsException.java
@@ -17,13 +17,17 @@
 package org.embulk.util.csv;
 
 /**
- * Thrown when {@link CsvTokenizer} encounters an unexpected extra trailing column (i.e. too many columns).
+ * Thrown when {@link CsvTokenizer} encounters too few or too many columns.
+ *
+ * <p>It corresponds to {@code CsvTokenizer.InvalidFormatException} in the original {@code embulk-standards}.
  */
-public class RecordHasUnexpectedTrailingColumnException extends InvalidCsvColumnsException {
+public abstract class InvalidCsvColumnsException extends InvalidCsvFormatException {
     /**
-     * Constructs a {@link RecordHasUnexpectedTrailingColumnException} with its default message.
+     * Constructs an {@link InvalidCsvColumnsException} with the specified detail message.
+     *
+     * @param message  the detail message
      */
-    public RecordHasUnexpectedTrailingColumnException() {
-        super("A record has an unexpected trailing column (i.e. too many columns).");
+    public InvalidCsvColumnsException(final String message) {
+        super(message);
     }
 }

--- a/src/main/java/org/embulk/util/csv/InvalidCsvQuotationException.java
+++ b/src/main/java/org/embulk/util/csv/InvalidCsvQuotationException.java
@@ -18,6 +18,8 @@ package org.embulk.util.csv;
 
 /**
  * Thrown when {@link CsvTokenizer} encounters an invalid format while parsing a quoted field.
+ *
+ * <p>It corresponds to {@code CsvTokenizer.InvalidValueException} in the original {@code embulk-standards}.
  */
 public abstract class InvalidCsvQuotationException extends InvalidCsvFormatException {
     /**

--- a/src/main/java/org/embulk/util/csv/RecordDoesNotHaveExpectedColumnException.java
+++ b/src/main/java/org/embulk/util/csv/RecordDoesNotHaveExpectedColumnException.java
@@ -19,7 +19,7 @@ package org.embulk.util.csv;
 /**
  * Thrown when {@link CsvTokenizer} is not able to find an expected column (i.e. too few columns).
  */
-public class RecordDoesNotHaveExpectedColumnException extends InvalidCsvFormatException {
+public class RecordDoesNotHaveExpectedColumnException extends InvalidCsvColumnsException {
     /**
      * Constructs a {@link RecordDoesNotHaveExpectedColumnException} with its default message.
      */


### PR DESCRIPTION
The Exceptions in `embulk-util-csv` did not correspond to the Exceptions in the original `embulk-standards`.

This pull request groups those Exceptions in the same way with the original `embulk-standards`.

https://github.com/embulk/embulk/blob/v0.9.25/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java#L471-L499