### PR TITLE
Fix the wrong state after end-of-file in quoted field

### DIFF
--- a/src/main/java/org/embulk/util/csv/CsvTokenizer.java
+++ b/src/main/java/org/embulk/util/csv/CsvTokenizer.java
@@ -441,6 +441,7 @@ public class CsvTokenizer {
                 this.line = this.unreadLines.removeFirst();
             } else {
                 if (!this.iterator.hasNext()) {
+                    this.line = null;
                     return false;
                 }
                 this.line = this.iterator.next();


### PR DESCRIPTION
This is a fix against https://github.com/embulk/embulk-parser-csv/issues/11

### Cause

The original `CsvTokenizer` in `embulk-standards` used `LineDecoder` as-is. It used `LineDecoder#poll` in `nextLine()` as below.

https://github.com/embulk/embulk/blob/v0.9.25/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java#L140-L143

When we split `CsvTokenizer` as a standalone library, it started to receive a generic `Iterator<String>`, not the specific `LineDecoder`, for a wider range of use.

https://github.com/embulk/embulk-standards/pull/22

However, it had a bug. When `this.iterator.hasNext()` is `false`, `this.line` still needed to be cleared as `null`.

### Fix

The commit d695f1bd305e4a1e47b8c454bb3267f3060f4e36 adds a test to confirm this bug, and the next commit 667692234463a4e5436dafa529ae3befe9af4552 fixes the bug.